### PR TITLE
Add support for Enterprise Linux

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-fpm_version: "1.2.0"
+fpm_version: "1.7.0"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,7 +15,7 @@ galaxy_info:
   categories:
   - development
   - system
-dependencies:
+  dependencies:
     - src: rvm_io.ruby
       tags: ruby
       become: yes

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,8 +9,19 @@ galaxy_info:
   - name: Ubuntu
     versions:
     - trusty
+  - name: Centos
+    versions:
+    - 6.x
   categories:
   - development
   - system
 dependencies:
-  - { role: "azavea.ruby", ruby_development: True }
+    - src: rvm_io.ruby
+      tags: ruby
+      become: yes
+      vars:
+        - rvm1_rubies: ['ruby-2.3.1']
+        - rvm1_install_flags: '--auto-dotfiles'     # Remove --user-install from defaults
+        - rvm1_install_path: /usr/local/rvm         # Set to system location
+        - rvm1_user: root                           # Need root account to access system location
+

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,7 +15,7 @@ galaxy_info:
   categories:
   - development
   - system
-  dependencies:
+dependencies:
     - src: rvm_io.ruby
       tags: ruby
       become: yes

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,12 +6,12 @@ galaxy_info:
   license: Apache
   min_ansible_version: 1.2
   platforms:
+  - name: EL
+    versions:
+    - all
   - name: Ubuntu
     versions:
-    - trusty
-  - name: Centos
-    versions:
-    - 6.x
+    - all
   categories:
   - development
   - system

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,7 @@
 ---
 - name: Install FPM
+  environment:
+    PATH: /usr/local/bin:{{ ansible_env.PATH }}
   gem: name=fpm
        version={{ fpm_version }}
        user_install=no


### PR DESCRIPTION
`azavea.ruby` only worked on ubuntu.

I've changed it to use `rvm` which works a lot more widely.